### PR TITLE
Morgan > main

### DIFF
--- a/attendance_tracker_app/src/PopUpMenu.css
+++ b/attendance_tracker_app/src/PopUpMenu.css
@@ -10,4 +10,7 @@
     background-color: var(--White);
     position: fixed;
     border-radius: 20px;
+    height: 237px;
+    width: 317px;
+    margin: 40px 0px 0px 50px;
 }

--- a/attendance_tracker_app/src/PopUpMenu.css
+++ b/attendance_tracker_app/src/PopUpMenu.css
@@ -1,0 +1,13 @@
+.modal {
+    position: fixed;
+    z-index: 1;
+    background-color: rgba(0,0,0,0.25);
+    width: 100%;
+    height: 100%;
+}
+
+.modal_content {
+    background-color: var(--White);
+    position: fixed;
+    border-radius: 20px;
+}

--- a/attendance_tracker_app/src/PopUpMenu.js
+++ b/attendance_tracker_app/src/PopUpMenu.js
@@ -1,0 +1,49 @@
+import React, {Component} from 'react'
+import './PopUpMenu.css'
+
+export default class PopUpMenu extends Component {
+  anchor = null;
+  constructor (props) {
+    super(props);
+
+    this.state = {
+        //Information to be fetched from the back end
+        courseName: "SWE4103",
+        hasLecture: true,
+        hasTutorial: true,
+        hasLab: true
+    }
+  }
+
+  handleClick = () => {this.props.toggle();}
+
+    render () {
+      let lectButton;
+      let tutButton;
+      let labButton;
+      //Add page references to buttons
+      if (this.state.hasLecture) {
+        lectButton = <button href="#">Lecture</button>
+      } else {lectButton = null}
+
+      if (this.state.hasTutorial) {
+        tutButton = <button href="#">Tutorial</button>
+      } else {tutButton = null}
+
+      if (this.state.hasLab) {
+        labButton = <button href="#">Lab</button>
+      } else {labButton = null}
+
+      return (
+        <div className="modal">
+          <div className="modal_content">
+            <p className="closeWindow" onClick={this.handleClick}>&times;</p>
+            <p>{this.state.courseName}</p>
+            {lectButton}
+            {tutButton}
+            {labButton}
+          </div>
+        </div>
+      )
+    }
+}

--- a/attendance_tracker_app/src/View.css
+++ b/attendance_tracker_app/src/View.css
@@ -64,7 +64,7 @@ body .View-Container {
     float: left;
     height: 190px;
     width: 315px;
-    background-color: var(--Red);
+    background-color: var(--BrightRed);
     border-radius: 20px;
     margin: 40px 0px 0px 50px;
     border: .1px solid var(--Gray);

--- a/attendance_tracker_app/src/View.css
+++ b/attendance_tracker_app/src/View.css
@@ -123,6 +123,6 @@ body .View-Container {
 }
 
 .View-Courses button:hover {
-    background-color: var(--BrightRed);
+    background-color: var(--Red);
     color: var(--White);
 }

--- a/attendance_tracker_app/src/View.css
+++ b/attendance_tracker_app/src/View.css
@@ -16,6 +16,19 @@ body .View-Container {
     float: left;
 }
 
+/* The course title text in the main menu cards */
+.View-Courses .Header-Text {
+    text-align: center;
+    padding: 35px;
+    float: none;
+}
+
+/* The buttons inside each course card */
+.View-Courses button {
+    background-color: var(--White);
+    color: var(--Red);
+}
+
 
 /* The system Logout button */
 .Logout {
@@ -49,7 +62,7 @@ body .View-Container {
 
 .View-Courses {
     float: left;
-    height: 235px;
+    height: 190px;
     width: 315px;
     background-color: var(--Red);
     border-radius: 20px;
@@ -105,10 +118,11 @@ body .View-Container {
     background-color: var(--BrightRed);
 }
 
-.View-Courses:hover {
-    background-color: var(--BrightRed);
-}
-
 .View-Remove-Course:hover {
     color: var(--BrightGray);
+}
+
+.View-Courses button:hover {
+    background-color: var(--BrightRed);
+    color: var(--White);
 }

--- a/attendance_tracker_app/src/View.js
+++ b/attendance_tracker_app/src/View.js
@@ -11,9 +11,9 @@ class View extends React.Component {
     }
   }
 
-  toggleMenu = () => {
+ /* toggleMenu = () => {
     this.setState({show: !this.state.show});
-  }
+  }*/
 
   render () {
     return (
@@ -26,19 +26,35 @@ class View extends React.Component {
         <div className='View-Container'>
           <h5 className='View-Title-Courses'>Your Courses</h5>
           <div className='View-Total-Frame'>
-            <a
-              //href='#'
-              className='View-Courses'
-              onClick={this.toggleMenu}>
+
+            <a className='View-Courses'>
+              <div className="Header-Text">SWE4103</div>
+              <button href="#">LECTURE</button>
+              <button href="#">TUTORIAL</button>
+              <button href="#">LAB</button>
             </a>
-            {this.state.show ? <PopUpMenu toggle = {this.toggleMenu} /> : null}
             
-            <a
-              //href='#'
-              className='View-Courses'
-              onClick={this.toggleMenu}>
+            <a className='View-Courses'>
+              <div className="Header-Text">CS3413</div>
+              <button href="#">LECTURE</button>
+              <button href="#">LAB</button>
             </a>
-            {this.state.show ? <PopUpMenu toggle={this.toggleMenu} /> : null}
+
+            <a className='View-Courses'>
+              <div className="Header-Text">CS3383</div>
+              <button href="#">LECTURE</button>
+              <button href="#">TUTORIAL</button>
+            </a>
+
+            <a className='View-Courses'>
+              <div className="Header-Text">ENGG4013</div>
+              <button href="#">LECTURE</button>
+            </a>
+
+            <a className='View-Courses'>
+              <div className="Header-Text">SWE4040</div>
+              <button href="#">LECTURE</button>
+            </a>
             
           </div>
           <div className='View-Area-Button View-Edit-Course'>

--- a/attendance_tracker_app/src/View.js
+++ b/attendance_tracker_app/src/View.js
@@ -1,13 +1,18 @@
 import React from 'react'
 import './View.css'
+import PopUpMenu from './PopUpMenu.js'
 
 class View extends React.Component {
   constructor (props) {
     super(props)
-    // Store local variable is state, not needed for now
     this.state = {
-      states: false
+      show: false
+      //states: false
     }
+  }
+
+  toggleMenu = () => {
+    this.setState({show: !this.state.show});
   }
 
   render () {
@@ -21,8 +26,19 @@ class View extends React.Component {
         <div className='View-Container'>
           <h5 className='View-Title-Courses'>Your Courses</h5>
           <div className='View-Total-Frame'>
-            <a href='#' className='View-Courses'></a>
-            <a href='#' className='View-Courses'></a>
+            <a
+              //href='#'
+              className='View-Courses'
+              onClick={this.toggleMenu}>
+            </a>
+            {this.state.show ? <PopUpMenu toggle = {this.toggleMenu} /> : null}
+            
+            <a
+              //href='#'
+              className='View-Courses'
+              onClick={this.toggleMenu}>
+            </a>
+            {this.state.show ? <PopUpMenu toggle={this.toggleMenu} /> : null}
             
           </div>
           <div className='View-Area-Button View-Edit-Course'>


### PR DESCRIPTION
Formatted course cards to show information and buttons directly, rather than needing to open a popup menu.  Button format slightly different than the updated wireframe (used basic <button> tag for course links, reversed colors for better visibility).  My branch doesn't have any of the classroom views in it, so course buttons have no functionality at present.  Classes are static; need to implement backend integration

![image](https://user-images.githubusercontent.com/55983792/100387957-b4b72700-2fff-11eb-8b39-6ade60429f30.png)
